### PR TITLE
Evaluate the list of Talk matches less often

### DIFF
--- a/YesAlready/Features/AddonTalkFeature.cs
+++ b/YesAlready/Features/AddonTalkFeature.cs
@@ -28,6 +28,8 @@ internal class AddonTalkFeature : BaseFeature
 
     private ClickTalk? clickTalk = null;
     private IntPtr lastTalkAddon = IntPtr.Zero;
+    // private string lastTalkTarget = string.Empty;
+    private bool matched = false;
 
     protected unsafe void AddonUpdate(AddonEvent eventType, AddonArgs addonInfo)
     {
@@ -35,11 +37,6 @@ internal class AddonTalkFeature : BaseFeature
 
         if (!P.Active || addon == null || !GenericHelpers.IsAddonReady(addon))
             return;
-
-        var target = Svc.Targets.Target;
-        var targetName = P.LastSeenTalkTarget = target != null
-            ? Utils.SEString.GetSeStringText(target.Name)
-            : string.Empty;
 
         if ((P.ForcedYesKeyPressed && !P.Config.SeparateForcedKeys) || P.ForcedTalkKeyPressed)
         {
@@ -50,20 +47,36 @@ internal class AddonTalkFeature : BaseFeature
             return;
         }
 
-        var nodes = P.Config.GetAllNodes().OfType<TalkEntryNode>();
-        foreach (var node in nodes)
-        {
-            if (!node.Enabled || string.IsNullOrEmpty(node.TargetText))
-                continue;
+        var target = Svc.Targets.Target;
+        var targetName = target != null
+            ? Utils.SEString.GetSeStringText(target.Name)
+            : string.Empty;
 
-            var matched = EntryMatchesTargetName(node, targetName);
-            if (!matched)
-                continue;
+        if (targetName != P.LastSeenTalkTarget) {
+            Svc.Log.Debug("Target Name: " + targetName + ", lastTalkTarget: " + P.LastSeenTalkTarget);
+            P.LastSeenTalkTarget = targetName;
+            matched = false;
 
+            var nodes = P.Config.GetAllNodes().OfType<TalkEntryNode>();
+
+            foreach (var node in nodes)
+            {
+                if (!node.Enabled || string.IsNullOrEmpty(node.TargetText))
+                    continue;
+                
+                matched = EntryMatchesTargetName(node, targetName);
+
+                if (matched) {
+                    Svc.Log.Debug("Talk match seen: " + matched + " Node: " + node.Name);
+                    break;    
+                }
+            }
+        }
+
+        if ( matched ) {
+            Svc.Log.Debug("AddonTalk: Advancing");
             if (clickTalk == null || lastTalkAddon != (IntPtr)addon)
                 clickTalk = ClickTalk.Using(lastTalkAddon = (IntPtr)addon);
-
-            Svc.Log.Debug("AddonTalk: Advancing");
             clickTalk.Click();
             return;
         }

--- a/YesAlready/Features/AddonTalkFeature.cs
+++ b/YesAlready/Features/AddonTalkFeature.cs
@@ -28,7 +28,7 @@ internal class AddonTalkFeature : BaseFeature
 
     private ClickTalk? clickTalk = null;
     private IntPtr lastTalkAddon = IntPtr.Zero;
-    private string lastTalkTarget = String.Empty;
+    private string lastTalkTarget = string.Empty;
     private bool matched = false;
 
     protected unsafe void AddonUpdate(AddonEvent eventType, AddonArgs addonInfo)

--- a/YesAlready/Features/AddonTalkFeature.cs
+++ b/YesAlready/Features/AddonTalkFeature.cs
@@ -28,6 +28,7 @@ internal class AddonTalkFeature : BaseFeature
 
     private ClickTalk? clickTalk = null;
     private IntPtr lastTalkAddon = IntPtr.Zero;
+    private string lastTalkTarget = String.Empty;
     private bool matched = false;
 
     protected unsafe void AddonUpdate(AddonEvent eventType, AddonArgs addonInfo)
@@ -36,6 +37,11 @@ internal class AddonTalkFeature : BaseFeature
 
         if (!P.Active || addon == null || !GenericHelpers.IsAddonReady(addon))
             return;
+
+        var target = Svc.Targets.Target;
+        var targetName = P.LastSeenTalkTarget = target != null
+            ? Utils.SEString.GetSeStringText(target.Name)
+            : string.Empty;
 
         if ((P.ForcedYesKeyPressed && !P.Config.SeparateForcedKeys) || P.ForcedTalkKeyPressed)
         {
@@ -46,14 +52,9 @@ internal class AddonTalkFeature : BaseFeature
             return;
         }
 
-        var target = Svc.Targets.Target;
-        var targetName = target != null
-            ? Utils.SEString.GetSeStringText(target.Name)
-            : string.Empty;
-
-        if (targetName != P.LastSeenTalkTarget) {
-            Svc.Log.Debug("Target Name: " + targetName + ", lastTalkTarget: " + P.LastSeenTalkTarget);
-            P.LastSeenTalkTarget = targetName;
+        if (targetName != lastTalkTarget) {
+            Svc.Log.Debug("Target Name: " + targetName + ", lastTalkTarget: " + lastTalkTarget);
+            lastTalkTarget = targetName;
             matched = false;
 
             var nodes = P.Config.GetAllNodes().OfType<TalkEntryNode>();

--- a/YesAlready/Features/AddonTalkFeature.cs
+++ b/YesAlready/Features/AddonTalkFeature.cs
@@ -28,7 +28,6 @@ internal class AddonTalkFeature : BaseFeature
 
     private ClickTalk? clickTalk = null;
     private IntPtr lastTalkAddon = IntPtr.Zero;
-    // private string lastTalkTarget = string.Empty;
     private bool matched = false;
 
     protected unsafe void AddonUpdate(AddonEvent eventType, AddonArgs addonInfo)

--- a/YesAlready/YesAlready.csproj
+++ b/YesAlready/YesAlready.csproj
@@ -10,7 +10,7 @@
         <Platforms>x64</Platforms>
         <LangVersion>preview</LangVersion>
         <PluginName>YesAlready</PluginName>
-        <DalamudDevPlugins>$(appdata)\XIVLauncher\devPlugins\$(PluginName)\</DalamudDevPlugins>
+        <DalamudDevPlugins>$(appdata)\XIVLauncher\dev\$(PluginName)\</DalamudDevPlugins>
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
         <DalamudPluginPath>$(appdata)\XIVLauncher\installedPlugins\$(PluginName)\$(version)</DalamudPluginPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/YesAlready/YesAlready.csproj
+++ b/YesAlready/YesAlready.csproj
@@ -10,7 +10,7 @@
         <Platforms>x64</Platforms>
         <LangVersion>preview</LangVersion>
         <PluginName>YesAlready</PluginName>
-        <DalamudDevPlugins>$(appdata)\XIVLauncher\dev\$(PluginName)\</DalamudDevPlugins>
+        <DalamudDevPlugins>$(appdata)\XIVLauncher\devPlugins\$(PluginName)\</DalamudDevPlugins>
         <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
         <DalamudPluginPath>$(appdata)\XIVLauncher\installedPlugins\$(PluginName)\$(version)</DalamudPluginPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
This is my fix to the issue #123 I raised about FPS dropping.

I saw that the entire list of NPCs in the user's Talk list is evaluated on every frame that any dialog box is open. If the user uses a lot of regex (like me) that could well get quite slow, block the frame, and result in decreased frame rate any time a dialogue box is open.

My changes make it so that the list of Talk skips is only tested on the frame that you start dialogue with a different targeted NPC. The state of whether or not a match is found in the list now persists across updates, so we don't have to keep testing the list and slowing the game down. The frame where the list is initially tested is still blocked, but that is much less noticeable. 

A similar change could probably be made anywhere else lists of regexes are evaluated in the Update event.