### PR TITLE
Remove DalamudApiLevel

### DIFF
--- a/YesAlready/YesAlready.json
+++ b/YesAlready/YesAlready.json
@@ -7,7 +7,6 @@
   "RepoUrl": "https://github.com/PunishXIV/YesAlready/",
   "IconUrl": "https://github.com/daemitus/YesAlready/raw/master/res/icon.png",
   "ApplicableVersion": "any",
-  "DalamudApiLevel": 12,
   "Tags": [
     "punish",
     "plugin"


### PR DESCRIPTION
By removing this, DalamudPackager should now just instead fill it in from the linked version, saving having to manually update the manifest while already updating the packager